### PR TITLE
Remove redundant target for desktop.in file

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,8 +135,6 @@ desktop_in_in_files = ibus-setup-m17n.desktop.in.in
 desktop_in_files = $(desktop_in_in_files:.in.in=.in)
 desktop_files = $(desktop_in_files:.desktop.in=.desktop)
 
-$(desktop_in_files): %.desktop.in: %.desktop.in.in Makefile
-	$(AM_V_GEN) $(edit) $< > $@.tmp && mv $@.tmp $@
 $(desktop_in_files):
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $@.in -o $@-t \
 	  -d $(top_srcdir)/po && mv $@-t $@


### PR DESCRIPTION
It will be done in desktop file generation since switched to gettext-0.19