### PR TITLE
Add support for the Meson build system

### DIFF
--- a/icons/meson.build
+++ b/icons/meson.build
@@ -1,0 +1,3 @@
+install_data('ibus-m17n.svg',
+  install_dir: get_option('datadir') / 'ibus-m17n' / 'icons',
+)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,56 @@
+project('ibus-m17n', 'c',
+  version: '1.4.7',
+  meson_version: '>= 0.53',
+)
+
+# Modules
+gnome = import('gnome')
+i18n = import('i18n')
+
+# Some variables
+po_dir = meson.current_source_dir() / 'po'
+config_h_inc = include_directories('.')
+
+# Dependencies
+ibus_dep = dependency('ibus-1.0', version: '>+ 1.4')
+m17n_dep = dependency('m17n-shell')
+glib_dep = dependency('glib-2.0')
+gio_dep = dependency('gio-2.0')
+
+if get_option('gtk') == '2'
+  gtk_dep = dependency('gtk+-2.0', version: '>= 2.12.12')
+elif
+  gtk_dep = dependency('gtk+-3.0', version: '>= 2.90.5')
+else
+  error('Unsupported value for \'gtk\' option')
+endif
+
+# config.h
+conf = configuration_data()
+conf.set_quoted('PACKAGE_NAME', meson.project_name())
+conf.set_quoted('PACKAGE_VERSION', meson.project_version())
+conf.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf.set10('HAVE_SETUP', get_option('gtk') != 'disabled')
+configure_file(output: 'config.h', configuration: conf)
+
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
+# Appdata
+install_data('m17n.appdata.xml',
+  install_dir: get_option('datadir') / 'metainfo',
+)
+
+# RPM spec
+ibus_m17n_rpm_spec = configure_file(
+  input: 'ibus-m17n.spec.in',
+  output: '@BASENAME@',
+  configuration: {
+    'VERSION': meson.project_version(),
+    'PACKAGE_VERSION': meson.project_version(),
+  },
+)
+
+# Subdirectories
+subdir('src')
+subdir('icons')
+subdir('po')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,6 @@
+option('gtk',
+  type: 'combo',
+  choices: [ '2', '3', 'disable' ],
+  value: '2',
+  description: 'Choose which GTK version to build for (or to disable)',
+)

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,0 +1,3 @@
+i18n.gettext(meson.project_name(),
+  preset: 'glib',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,114 @@
+m17ncommon_cflags = [
+  '-DPKGDATADIR="@0@"'.format(get_option('prefix') / get_option('datadir') / meson.project_name()),
+  '-DLIBEXECDIR="@0@"'.format(get_option('prefix') / get_option('libexecdir')),
+]
+
+# Little helper library to implement common functionality
+m17ncommon_lib = static_library('m17ncommon',
+  files('m17nutil.c'),
+  dependencies: ibus_dep,
+  c_args: m17ncommon_cflags,
+  include_directories: config_h_inc,
+)
+
+# Engine
+ibus_engine_m17n_sources = files(
+  'main.c',
+  'engine.c',
+)
+
+ibus_engine_m17n_deps = [
+  ibus_dep,
+  m17n_dep,
+]
+
+executable('ibus-engine-m17n',
+  ibus_engine_m17n_sources,
+  dependencies: ibus_engine_m17n_deps,
+  include_directories: config_h_inc,
+  link_with: m17ncommon_lib,
+  c_args: m17ncommon_cflags,
+  install: true,
+  install_dir: get_option('libexecdir'),
+)
+
+# IBus components
+configure_file(
+  input: 'm17n.xml.in',
+  output: '@BASENAME@',
+  configuration: {
+    'VERSION': meson.project_version(),
+    'libexecdir': get_option('prefix') / get_option('libexecdir'),
+    'pkgdatadir': get_option('prefix') / get_option('datadir') / meson.project_name(),
+  },
+  install: true,
+  install_dir: get_option('datadir') / 'ibus' / 'component',
+)
+
+install_data('default.xml',
+  install_dir: get_option('datadir') / 'ibus' / 'component',
+)
+
+# UI setup
+if get_option('gtk') != 'disabled'
+  ibus_setup_m17n_sources = files(
+    'setup.c',
+  )
+
+  ibus_setup_m17n_deps = [
+    gio_dep,
+    gtk_dep,
+    ibus_dep,
+    m17n_dep,
+  ]
+
+  ibus_setup_m17n = executable('ibus-setup-m17n',
+    ibus_setup_m17n_sources,
+    include_directories: config_h_inc,
+    dependencies: ibus_setup_m17n_deps,
+    link_with: m17ncommon_lib,
+    c_args: m17ncommon_cflags,
+  )
+
+  install_data('ibus-m17n-preferences.ui',
+    install_dir: get_option('datadir') / meson.project_name() / 'setup',
+  )
+
+  desktop_file = i18n.merge_file(
+    input: configure_file(
+      input: 'ibus-setup-m17n.desktop.in.in',
+      output: '@BASENAME@',
+      configuration: {
+        'libexecdir': get_option('prefix') / get_option('libexecdir'),
+      },
+    ),
+    output: '@BASENAME@',
+    type: 'desktop',
+    po_dir: po_dir,
+    install: true,
+    install_dir: get_option('datadir') / 'applications',
+  )
+endif
+
+# GSchema
+install_data('org.freedesktop.ibus.engine.m17n.gschema.xml',
+  install_dir: get_option('datadir') / 'glib-2.0' / 'schemas',
+)
+
+# Tests
+ibus_m17n_test_bin = executable('test-m17n',
+  files('test.c'),
+  dependencies: [
+    ibus_dep,
+    m17n_dep,
+  ],
+  link_with: m17ncommon_lib,
+  include_directories: config_h_inc,
+)
+
+test('m17n',
+  ibus_m17n_test_bin,
+  env: [
+    'IBUS_M17N_PKGDATADIR=@0@'.format(meson.current_build_dir()),
+  ],
+)


### PR DESCRIPTION
See the [Meson website] for a full reference. To build, test and/or
install ibus-m17n, you essentially need the following commands:

```
$ meson --prefix=/usr _build
$ meson compile -C _build
$ meson test -C _build
$ meson install -C _build
```

[Meson website]: http://mesonbuild.com/